### PR TITLE
feat: remove ReactRefresh and HotModuleReplacement plugins for react-scripts v4

### DIFF
--- a/src/clean-for-cypress.js
+++ b/src/clean-for-cypress.js
@@ -164,9 +164,7 @@ function cleanForCypress(opts, webpackOptions) {
 
     // TODO how to better find a plugin? By name? By constructor?
     webpackOptions.plugins = webpackOptions.plugins.filter((plugin) => {
-      // means the plugin is DefinePlugin
-      // https://webpack.js.org/plugins/define-plugin/
-      return typeof plugin.definitions === 'object'
+      return ["DefinePlugin", "HotModuleReplacementPlugin", "ReactRefreshPlugin"].includes(plugin.constructor.name)
     })
 
     debug('filtered plugins %o', webpackOptions.plugins)


### PR DESCRIPTION
This also should make it possible to use the development-time webpack config of next.js 