### PR TITLE
fix: addFolderToBabelTranspile. TypeError: Cannot read property 'includes' of undefined

### DIFF
--- a/src/clean-for-cypress.js
+++ b/src/clean-for-cypress.js
@@ -68,6 +68,12 @@ const addFolderToBabelTranspile = (addFolderToTranspile, webpackOptions) => {
     return
   }
   debug('babel rule %o', babelRule)
+
+  if (!babelRule.include) {
+    debug('could not find Babel include condition')
+    return
+  }
+
   if (typeof babelRule.include === 'string') {
     babelRule.include = [babelRule.include]
   }


### PR DESCRIPTION
Closes #18