### PR TITLE
Allow ProvidePlugin from webpack.

### DIFF
--- a/src/clean-for-cypress.js
+++ b/src/clean-for-cypress.js
@@ -169,8 +169,9 @@ function cleanForCypress(opts, webpackOptions) {
     webpackOptions.plugins = webpackOptions.plugins || []
 
     // TODO how to better find a plugin? By name? By constructor?
+    const acceptedPlugins = ["DefinePlugin", "HotModuleReplacementPlugin", "ProvidePlugin", "ReactRefreshPlugin"]
     webpackOptions.plugins = webpackOptions.plugins.filter((plugin) => {
-      return ["DefinePlugin", "HotModuleReplacementPlugin", "ReactRefreshPlugin"].includes(plugin.constructor.name)
+      return acceptedPlugins.includes(plugin.constructor.name)
     })
 
     debug('filtered plugins %o', webpackOptions.plugins)


### PR DESCRIPTION
#15 created a regression for my project. We use webpack's [`ProvidePlugin`](https://webpack.js.org/plugins/provide-plugin/) to make `jQuery` globally available for our project. (Yes, global is terrible, I'm dealing with a legacy project.)

I'm not sure if it was intended to be so restrictive about which webpack plugins could be passed along to Cypress. The PR didn't provide much context.

I'm a little surprised my project hits this codepath, as we don't use `react-scripts` and aren't inside a CRA. I was also confused by how the PR says **remove** HMR and ReactRefresh, while the code diff only includes those plugins and ignores others.

So, there's several unanswered questions for me, which may change the nature of what the right "fix" should be.

Hopefully this change would be a welcome addition!